### PR TITLE
Write data fields before files (S3 Upload Error)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/requests.go
+++ b/requests.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/cookiejar"
@@ -288,7 +287,7 @@ func (resp *Response) Content() []byte {
 		Body = reader
 	}
 
-	resp.content, err = ioutil.ReadAll(Body)
+	resp.content, err = io.ReadAll(Body)
 	if err != nil {
 		return nil
 	}
@@ -376,7 +375,7 @@ func (req *Request) PostJson(origurl string, args ...interface{}) (resp *Respons
 				req.Header.Set(k, v)
 			}
 		case string:
-			req.setBodyRawBytes(ioutil.NopCloser(strings.NewReader(arg.(string))))
+			req.setBodyRawBytes(io.NopCloser(strings.NewReader(arg.(string))))
 		case Auth:
 			// a{username,password}
 			req.httpreq.SetBasicAuth(a[0], a[1])
@@ -386,7 +385,7 @@ func (req *Request) PostJson(origurl string, args ...interface{}) (resp *Respons
 			if err != nil {
 				return nil, err
 			}
-			req.setBodyRawBytes(ioutil.NopCloser(b))
+			req.setBodyRawBytes(io.NopCloser(b))
 		}
 	}
 
@@ -513,7 +512,7 @@ func (req *Request) setBodyBytes(Forms url.Values) {
 
 	// maybe
 	data := Forms.Encode()
-	req.httpreq.Body = ioutil.NopCloser(strings.NewReader(data))
+	req.httpreq.Body = io.NopCloser(strings.NewReader(data))
 	req.httpreq.ContentLength = int64(len(data))
 }
 
@@ -555,7 +554,7 @@ func (req *Request) buildFilesAndForms(files []map[string]string, datas []map[st
 	w.Close()
 	// set file header example:
 	// "Content-Type": "multipart/form-data; boundary=------------------------7d87eceb5520850c",
-	req.httpreq.Body = ioutil.NopCloser(bytes.NewReader(b.Bytes()))
+	req.httpreq.Body = io.NopCloser(bytes.NewReader(b.Bytes()))
 	req.httpreq.ContentLength = int64(b.Len())
 	req.Header.Set("Content-Type", w.FormDataContentType())
 }

--- a/requests.go
+++ b/requests.go
@@ -530,6 +530,12 @@ func (req *Request) buildFilesAndForms(files []map[string]string, datas []map[st
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
 
+	for _, data := range datas {
+		for k, v := range data {
+			w.WriteField(k, v)
+		}
+	}
+
 	for _, file := range files {
 		for k, v := range file {
 			part, err := w.CreateFormFile(k, v)
@@ -542,12 +548,6 @@ func (req *Request) buildFilesAndForms(files []map[string]string, datas []map[st
 			if err != nil {
 				panic(err)
 			}
-		}
-	}
-
-	for _, data := range datas {
-		for k, v := range data {
-			w.WriteField(k, v)
 		}
 	}
 


### PR DESCRIPTION
I want to make a POST request to S3 to upload a file via presigned URL. Then I get the following error: 

```
InvalidArgument: Bucket POST must contain a field named 'key'.  If it is specified, please check the order of the fields.
```
The issue is that S3  ignores all other fields after files, so it expects the key field to appear first.
Fixed it by writing data fields before files in method `buildFilesAndForms`.